### PR TITLE
sscc refactor add generate

### DIFF
--- a/sscc.go
+++ b/sscc.go
@@ -7,10 +7,13 @@ import (
 	"strings"
 )
 
-const lenghtSSCC = 17
+const ssccBodyLen = 17
 
+var ssccPrefixRE = regexp.MustCompile(`^\d{7,12}$`)
+
+// Sscc returns the 18-digit SSCC (17-digit body + check digit) without the AI "00".
 func Sscc(code string) (out string, err error) {
-	if len(code) != lenghtSSCC {
+	if len(code) != ssccBodyLen {
 		return "", fmt.Errorf("wrong lenght code %s", code)
 	}
 	// Validate that code contains only digits
@@ -36,17 +39,22 @@ func roundUp(val int) int {
 	return 10 * ((val + 9) / 10)
 }
 
+// GenerateSSCC builds and returns the 20-digit string with AI "00" prefixed
+// from a 7–12 digit prefix and non-negative sequence i.
 func GenerateSSCC(i int, prefix string) (string, error) {
+	if i < 0 {
+		return "", fmt.Errorf("invalid i: must be non-negative")
+	}
 	// Must be 7–12 digits
-	if matched, _ := regexp.MatchString(`^\d{7,12}$`, prefix); !matched {
+	if !ssccPrefixRE.MatchString(prefix) {
 		return "", fmt.Errorf("invalid SSCC prefix %q: must be 7–12 digits", prefix)
 	}
 	prefixLength := len(prefix)
 	number := strconv.Itoa(i)
-	if len(number) > lenghtSSCC-prefixLength {
-		return "", fmt.Errorf("invalid i number: must be %d digits", lenghtSSCC-prefixLength)
+	if len(number) > ssccBodyLen-prefixLength {
+		return "", fmt.Errorf("invalid i number: must be %d digits", ssccBodyLen-prefixLength)
 	}
-	padding := strings.Repeat("0", lenghtSSCC-prefixLength-len(number))
+	padding := strings.Repeat("0", ssccBodyLen-prefixLength-len(number))
 	code := prefix + padding + number
 	sscc, err := Sscc(code)
 	if err != nil {

--- a/sscc_test.go
+++ b/sscc_test.go
@@ -6,35 +6,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSsccTableDriven(t *testing.T) {
-	// Defining the columns of the table
-	var tests = []struct {
-		name  string
-		input string
-		want  string
-		err   bool
-	}{
-		// the table itself
-		{"test 0", "", "", true},
-		{"test 1", "46164463019900001", "00461644630199000016", false},
-		{"test 2", "46164463019901", "00000461644630199016", false},
-		{"test 3", "46164463A19901", "", true},
-		{"test 4", "55546164463019900001", "00555461644630199004", false},
-	}
+var testsParse = []struct {
+	name   string
+	err    bool
+	prefix string
+	i      int
+	result string
+}{
+	// the table itself
+	{"test 0", true, "123456", 0, ""},
+	{"test 1", false, "1234567", 0, "00123456700000000000"},
+	{"test 3", false, "1234567890", 0, "00123456789000000005"},
+	{"test 4", false, "1234567890", 1234567, "00123456789012345675"},
+	{"test 5", true, "1234567890", 1234567890, "00123456789001234560"},
+	{"test 6", false, "123456789", 12345, "00123456789000123452"},
+}
 
+func TestGenerateSSCC(t *testing.T) {
 	// The execution loop
-	for _, tt := range tests {
+	for _, tt := range testsParse {
 		t.Run(tt.name, func(t *testing.T) {
-			ans, err := Sscc(tt.input)
+			sscc, err := GenerateSSCC(tt.i, tt.prefix)
 			if tt.err {
-				assert.NotNil(t, err)
+				assert.NotNil(t, err, "ожидаем ошибку")
 			} else {
 				// ожидаем отсутствие ошибки
 				assert.Nil(t, err)
-			}
-			// проверяем результат
-			if ans != tt.want {
-				t.Errorf("got %s, want %s", ans, tt.want)
+				assert.Equal(t, sscc, tt.result, "ожидаемое значение")
 			}
 		})
 	}

--- a/sscc_test.go
+++ b/sscc_test.go
@@ -20,19 +20,22 @@ var testsParse = []struct {
 	{"test 4", false, "1234567890", 1234567, "00123456789012345675"},
 	{"test 5", true, "1234567890", 1234567890, "00123456789001234560"},
 	{"test 6", false, "123456789", 12345, "00123456789000123452"},
+	{"negative i", true, "1234567", -1, ""},
 }
 
 func TestGenerateSSCC(t *testing.T) {
 	// The execution loop
+	// Capture tt for safety, use NoError, and put expected before actual in Equal
 	for _, tt := range testsParse {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			sscc, err := GenerateSSCC(tt.i, tt.prefix)
 			if tt.err {
 				assert.NotNil(t, err, "ожидаем ошибку")
 			} else {
 				// ожидаем отсутствие ошибки
-				assert.Nil(t, err)
-				assert.Equal(t, sscc, tt.result, "ожидаемое значение")
+				assert.NoError(t, err)
+				assert.Equal(t, tt.result, sscc, "ожидаемое значение")
 			}
 		})
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GenerateSSCC(prefix, number) to create a valid 20‑digit SSCC with automatic padding and check digit.
- Refactor
  - Enforced strict 17‑digit input for SSCC validation; non‑17‑digit inputs now error.
  - Removed implicit padding/truncation; inputs must already be correctly sized.
  - Updated SSCC output format to exclude the leading “00”; use GenerateSSCC for the full 20‑digit value.
- Tests
  - Rewrote tests to cover GenerateSSCC with parameterized cases and clearer assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->